### PR TITLE
send_rpc: fix missing 'result' key when t is nil

### DIFF
--- a/gen/tea_leaves/lsp_reader_writer.lua
+++ b/gen/tea_leaves/lsp_reader_writer.lua
@@ -133,7 +133,7 @@ function LspReaderWriter:send_rpc(id, t)
    self:_encode({
       jsonrpc = "2.0",
       id = json_nullable(id),
-      result = t,
+      result = json_nullable(t),
    })
 end
 

--- a/src/tea_leaves/lsp_reader_writer.tl
+++ b/src/tea_leaves/lsp_reader_writer.tl
@@ -133,7 +133,7 @@ function LspReaderWriter:send_rpc(id: integer, t: {string:any})
    self:_encode {
       jsonrpc = "2.0",
       id = json_nullable(id),
-      result = t,
+      result = json_nullable(t),
    }
 end
 


### PR DESCRIPTION
This PR fixes the following error in vscode's `LanguageClient` when the language server answers with a `nil` result:

```
[Error - 1:36:13 PM] Request textDocument/completion failed.
Error: The received response has neither a result nor an error property.
	at handleInvalidMessage (/home/patrick/Code/vscode-teal/node_modules/vscode-jsonrpc/lib/common/connection.js:672:40)
```

It was complaining that the 'result' field was missing.